### PR TITLE
deps(phase1): close CVEs and upgrade build tooling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'org.springframework.boot' version '2.4.5'
-    id 'com.palantir.docker' version '0.26.0'
+    id 'com.palantir.docker' version '0.36.0'
     id "io.spring.dependency-management" version "1.0.11.RELEASE"
     id 'java'
     id 'jacoco'
@@ -11,17 +11,17 @@ version = '2.3.0'
 sourceCompatibility = '11'
 
 ext {
-    jacksonVersion = '2.9.10'
-    junitVersion = '5.7.1'
+    junitVersion = '5.11.4'
     keycloakVersion = '6.0.1'
-    lombokVersion = '1.18.22'
+    lombokVersion = '1.18.38'
     springBootVersion = '2.4.5'
     springSecurityVersion = '5.4.6'
-    testContainersVersion = '1.20.1'
+    testContainersVersion = '1.20.6'
     swaggerVersion = '2.9.2'
 }
 
-ext['log4j2.version'] = '2.16.0'
+ext['jackson.version'] = '2.17.3'
+ext['log4j2.version'] = '2.24.3'
 
 configurations {
     developmentOnly
@@ -30,6 +30,14 @@ configurations {
     }
     compileOnly {
         extendsFrom annotationProcessor
+    }
+    configureEach {
+        resolutionStrategy.eachDependency { details ->
+            if (details.requested.group == 'org.apache.commons' && details.requested.name == 'commons-compress') {
+                details.useVersion '1.27.1'
+                details.because 'CVE-2024-25710, CVE-2024-26308 fixed in 1.26.0'
+            }
+        }
     }
 }
 
@@ -41,24 +49,6 @@ springBoot {
     buildInfo()
 }
 
-sourceSets {
-    main {
-        java {
-            srcDir 'src/main/java'
-        }
-        resources {
-            srcDir 'src/main/resources'
-        }
-    }
-    test {
-        java {
-            srcDir 'src/test/java'
-        }
-        resources {
-            srcDir 'src/test/resources'
-        }
-    }
-}
 
 test {
     useJUnitPlatform()
@@ -67,14 +57,14 @@ test {
 }
 
 jacoco {
-    toolVersion = "0.8.7"
+    toolVersion = "0.8.13"
 }
 
 jacocoTestReport {
     dependsOn test
     reports {
-        xml.enabled true
-        html.enabled true
+        xml.required = true
+        html.required = true
     }
 }
 
@@ -92,7 +82,7 @@ dependencies {
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
 
     // Jackson
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:${jacksonVersion}"
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
 
     // Swagger
     implementation "io.springfox:springfox-swagger2:${swaggerVersion}"
@@ -105,7 +95,7 @@ dependencies {
     testImplementation "org.springframework.boot:spring-boot-starter-test:${springBootVersion}"
     testImplementation "org.springframework.security:spring-security-test:${springSecurityVersion}"
     testImplementation "org.junit.jupiter:junit-jupiter:${junitVersion}"
-    testCompile "org.testcontainers:junit-jupiter:${testContainersVersion}"
+    testImplementation "org.testcontainers:junit-jupiter:${testContainersVersion}"
 }
 
 dependencyManagement {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gradle.enterprise' version '3.5.1'
+    id 'com.gradle.enterprise' version '3.16.2'
 }
 
 gradleEnterprise {

--- a/src/main/java/net/gendercomics/api/model/jackson/KeywordDeserializer.java
+++ b/src/main/java/net/gendercomics/api/model/jackson/KeywordDeserializer.java
@@ -6,8 +6,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import net.gendercomics.api.model.*;
 
-import javax.xml.bind.DatatypeConverter;
 import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 
 public class KeywordDeserializer extends StdDeserializer<Keyword> {
@@ -61,7 +62,8 @@ public class KeywordDeserializer extends StdDeserializer<Keyword> {
     }
 
     private Date dateFromJson(JsonNode json, String nodeName) {
-        return json.get(nodeName).asText().equals("null") ? null : DatatypeConverter.parseDateTime(json.get(nodeName).asText()).getTime();
+        return json.get(nodeName).asText().equals("null") ? null :
+                Date.from(OffsetDateTime.parse(json.get(nodeName).asText(), DateTimeFormatter.ISO_OFFSET_DATE_TIME).toInstant());
     }
 
     private String valueFromJson(JsonNode json, String nodeName) {


### PR DESCRIPTION
## Summary

- **Jackson 2.9.10 → 2.17.3** (all modules via BOM override): closes CVE-2020-25649 (XXE, 7.5), CVE-2021-46877 (DoS, 7.5), CVE-2022-42003/42004 (DoS, 7.5), CVE-2025-52999 (StackOverflow, 7.5)
- **Log4j2 2.16.0 → 2.24.3**: closes CVE-2021-45105 (infinite recursion, 7.5)
- **commons-compress forced 1.24.0 → 1.27.1**: closes CVE-2024-25710 (8.1), CVE-2024-26308 (5.5) — transitive via TestContainers
- Gradle wrapper 6.8 → 7.6.4; com.palantir.docker 0.26.0 → 0.36.0; com.gradle.enterprise 3.5.1 → 3.16.2
- Lombok 1.18.22 → 1.18.38; JUnit 5.7.1 → 5.11.4; TestContainers 1.20.1 → 1.20.6; JaCoCo 0.8.7 → 0.8.13
- Fix Gradle 7 deprecations: testCompile → testImplementation, xml.enabled → xml.required, remove redundant default sourceSets block
- KeywordDeserializer: replace removed javax.xml.bind.DatatypeConverter with java.time.OffsetDateTime

## Remaining CVEs (addressed in Phase 2)

Spring Boot 2.4.5 itself carries CVEs in spring-core, spring-beans, logback, snakeyaml, and spring-data-mongodb — all resolved by the planned Spring Boot 2.7.18 upgrade.

## Test plan

- [x] All 56 tests pass locally (./gradlew test)
- [x] JaCoCo report generates (./gradlew jacocoTestReport)
- [x] CI green on deps/phase1-housekeeping

Generated with [Claude Code](https://claude.com/claude-code)