### PR TITLE
deps(phase3): switch compile target to Java 17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,12 @@ plugins {
 
 group = 'net.gendercomics.api'
 version = '2.3.0'
-sourceCompatibility = '11'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
 
 ext {
     junitVersion = '5.11.4'

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,6 +6,7 @@ pluginManagement {
 
 plugins {
     id 'com.gradle.enterprise' version '3.16.2'
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
 }
 
 gradleEnterprise {


### PR DESCRIPTION
## Summary

- Replace `sourceCompatibility = '11'` with a Gradle toolchain block targeting Java 17
- Add `org.gradle.toolchains.foojay-resolver-convention 0.8.0` to `settings.gradle` — Gradle auto-provisions the JDK on first build if not locally installed
- No source changes required (`javax.xml.bind` was already removed from `KeywordDeserializer` in Phase 1)

Java 17 is a prerequisite for the Spring Boot 3 upgrade in Phase 6.

## Test plan

- [x] All 56 tests pass on Java 17 (`./gradlew test`)
- [x] JDK auto-provisioned via foojay: `eclipse_adoptium-17-amd64-windows`

Generated with [Claude Code](https://claude.com/claude-code)