### PR TITLE
deps(phase4): replace SpringFox with SpringDoc OpenAPI 1.8.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,6 @@ ext {
     lombokVersion = '1.18.38'
     springBootVersion = '2.7.18'
     testContainersVersion = '1.20.6'
-    swaggerVersion = '2.9.2'
 }
 
 ext['jackson.version'] = '2.17.3'
@@ -88,9 +87,8 @@ dependencies {
     // Jackson
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-xml"
 
-    // Swagger
-    implementation "io.springfox:springfox-swagger2:${swaggerVersion}"
-    implementation "io.springfox:springfox-swagger-ui:${swaggerVersion}"
+    // SpringDoc OpenAPI
+    implementation "org.springdoc:springdoc-openapi-ui:1.8.0"
 
     // Keycloak
     implementation "org.keycloak:keycloak-spring-boot-starter:${keycloakVersion}"

--- a/src/main/java/net/gendercomics/api/GenderComicsApi.java
+++ b/src/main/java/net/gendercomics/api/GenderComicsApi.java
@@ -1,53 +1,38 @@
 package net.gendercomics.api;
 
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.info.BuildProperties;
 import org.springframework.context.annotation.Bean;
-import springfox.documentation.builders.ApiInfoBuilder;
-import springfox.documentation.builders.PathSelectors;
-import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.service.ApiInfo;
-import springfox.documentation.service.Contact;
-import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @SpringBootApplication
-@EnableSwagger2
+@RequiredArgsConstructor(onConstructor = @__(@Autowired))
 public class GenderComicsApi {
 
-    @Autowired
-    private BuildProperties _buildProperties;
+    private final BuildProperties _buildProperties;
 
     public static void main(String[] args) {
         SpringApplication.run(GenderComicsApi.class, args);
     }
 
     @Bean
-    public Docket api() {
-        return new Docket(DocumentationType.SWAGGER_2)
-                .groupName(_buildProperties.getGroup())
-                .apiInfo(apiInfo())
-                .select()
-                .apis(RequestHandlerSelectors.basePackage("net.gendercomics.api"))
-                .paths(PathSelectors.any())
-                .build();
-    }
-
-    private ApiInfo apiInfo() {
-        return new ApiInfoBuilder()
-                .title("gendercomics API")
-                .description("The gendercomics.net API provides access to the gendercomics database." +
-                        "The database stores the results (comics, authors, artists, publishers, articles, bolg post, etc.) " +
-                        "of the research project 'Visualities of Gender in German-language Comics'")
-                .termsOfServiceUrl("http://gendercomics.net")
-                .contact(new Contact("Michael Litschauer", "", "michael.litschauer@gmail.com"))
-                .license("Apache License Version 2.0")
-                .licenseUrl("https://gendercomics.net/LICENSE")
-                .version(_buildProperties.getVersion())
-                .build();
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("gendercomics API")
+                        .version(_buildProperties.getVersion())
+                        .description("The gendercomics.net API provides access to the gendercomics database." +
+                                "The database stores the results (comics, authors, artists, publishers, articles, blog posts, etc.) " +
+                                "of the research project 'Visualities of Gender in German-language Comics'")
+                        .termsOfService("http://gendercomics.net")
+                        .contact(new Contact().name("Michael Litschauer").email("michael.litschauer@gmail.com"))
+                        .license(new License().name("Apache License Version 2.0").url("https://gendercomics.net/LICENSE")));
     }
 
 }

--- a/src/main/java/net/gendercomics/api/controller/ComicController.java
+++ b/src/main/java/net/gendercomics/api/controller/ComicController.java
@@ -1,9 +1,9 @@
 package net.gendercomics.api.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import net.gendercomics.api.data.service.ComicService;
 import net.gendercomics.api.model.Comic;
@@ -11,12 +11,11 @@ import net.gendercomics.api.model.ComicType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
-import springfox.documentation.annotations.ApiIgnore;
 
 import java.security.Principal;
 import java.util.List;
 
-@Api(tags = {"comics"})
+@Tag(name = "comics")
 @RestController
 @CrossOrigin
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
@@ -26,80 +25,80 @@ public class ComicController {
 
     /*** public endpoints ***/
 
-    @ApiOperation("get all comics")
+    @Operation(summary = "get all comics")
     @GetMapping(path = "/comics", produces = MediaType.APPLICATION_JSON_VALUE)
     public List<Comic> getAllComics() {
         return _comicService.findAll();
     }
 
-    @ApiOperation("get all comics")
+    @Operation(summary = "get all comics")
     @GetMapping(path = "/comicsList", produces = MediaType.APPLICATION_JSON_VALUE)
     public List<Comic> getAllComicsForList() {
         return _comicService.findAllForList();
     }
 
-    @ApiOperation("get all comic parents (anthologies, magazines")
+    @Operation(summary = "get all comic parents (anthologies, magazines")
     @GetMapping(path = "/comics/parents", produces = MediaType.APPLICATION_JSON_VALUE)
     public List<Comic> getAllParents() {
         return _comicService.findByTypes(ComicType.anthology, ComicType.magazine);
     }
 
-    @ApiOperation("get comics by type (ComicType.anthology, ComicType.magazine, ComicType.series)")
+    @Operation(summary = "get comics by type (ComicType.anthology, ComicType.magazine, ComicType.series)")
     @GetMapping(path = "/comics/type/{type}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public List<Comic> getByType(@ApiParam @PathVariable("type") String type) {
+    public List<Comic> getByType(@Parameter @PathVariable("type") String type) {
         if ("series".equals(type)) {
             return _comicService.findByTypes(ComicType.comic_series, ComicType.publishing_series);
         }
         return _comicService.findByTypes(ComicType.valueOf(type));
     }
 
-    @ApiOperation("get a comic")
+    @Operation(summary = "get a comic")
     @GetMapping(path = "/comics/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public Comic getComic(@ApiParam @PathVariable("id") String id) {
+    public Comic getComic(@Parameter @PathVariable("id") String id) {
         return _comicService.getComic(id);
     }
 
-    @ApiOperation("get a comic in XML format")
+    @Operation(summary = "get a comic in XML format")
     @GetMapping(path = "/comics/{id}/xml", produces = MediaType.APPLICATION_XML_VALUE)
-    public String getComicAsXml(@ApiParam @PathVariable("id") String id) throws JsonProcessingException {
+    public String getComicAsXml(@Parameter @PathVariable("id") String id) throws JsonProcessingException {
         return _comicService.getComicAsXml(id);
     }
 
-    @ApiOperation("get the number of comics in the database")
+    @Operation(summary = "get the number of comics in the database")
     @GetMapping(path = "/comics/count", produces = MediaType.APPLICATION_JSON_VALUE)
     public long getComicCount() {
         return _comicService.getComicCount();
     }
 
-    @ApiOperation("get a comic by title")
+    @Operation(summary = "get a comic by title")
     @GetMapping(path = "/comics/title/{title}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public List<Comic> getComicByTitle(@ApiParam @PathVariable("title") String title) {
+    public List<Comic> getComicByTitle(@Parameter @PathVariable("title") String title) {
         return _comicService.findByTitle(title);
     }
 
-    @ApiOperation("verify if a comic title exists in the database")
+    @Operation(summary = "verify if a comic title exists in the database")
     @GetMapping(path = "/comics/title/exists/{title}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public boolean getTitleExists(@ApiParam @PathVariable("title") String title) {
+    public boolean getTitleExists(@Parameter @PathVariable("title") String title) {
         return _comicService.titleExists(title);
     }
 
     /*** admin endpoints - secured, only authorized access allowed ***/
 
-    @ApiOperation("insert a comic")
+    @Operation(summary = "insert a comic")
     @PostMapping(path = "/comics")
-    public Comic insertComic(@ApiIgnore Principal principal, @ApiParam(required = true) @RequestBody Comic comic) {
+    public Comic insertComic(@Parameter(hidden = true) Principal principal, @Parameter(required = true) @RequestBody Comic comic) {
         return _comicService.save(comic, principal.getName());
     }
 
-    @ApiOperation("update a comic")
+    @Operation(summary = "update a comic")
     @PutMapping(path = "/comics/{id}")
-    public Comic saveComic(@ApiIgnore Principal principal, @ApiParam(required = true) @RequestBody Comic comic) {
+    public Comic saveComic(@Parameter(hidden = true) Principal principal, @Parameter(required = true) @RequestBody Comic comic) {
         return _comicService.save(comic, principal.getName());
     }
 
-    @ApiOperation("delete a comic")
+    @Operation(summary = "delete a comic")
     @DeleteMapping(path = "/comics/{id}")
-    public void deleteComic(@ApiIgnore Principal principal, @ApiParam(required = true) @PathVariable String id) {
+    public void deleteComic(@Parameter(hidden = true) Principal principal, @Parameter(required = true) @PathVariable String id) {
         _comicService.delete(id);
     }
 

--- a/src/main/java/net/gendercomics/api/controller/CommonController.java
+++ b/src/main/java/net/gendercomics/api/controller/CommonController.java
@@ -1,7 +1,7 @@
 package net.gendercomics.api.controller;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import net.gendercomics.api.data.service.ComicService;
 import net.gendercomics.api.data.service.KeywordService;
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Api(tags = {"common endpoints"})
+@Tag(name = "common endpoints")
 @RestController
 @CrossOrigin
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
@@ -29,13 +29,13 @@ public class CommonController {
     private final RoleService _roleService;
     private final KeywordService _keywordService;
 
-    @ApiOperation("retrieve API information")
+    @Operation(summary = "retrieve API information")
     @GetMapping(path = "/info", produces = MediaType.APPLICATION_JSON_VALUE)
     public BuildProperties getInfo() {
         return _buildProperties;
     }
 
-    @ApiOperation("retrieve API information")
+    @Operation(summary = "retrieve API information")
     @GetMapping(path = "/count", produces = MediaType.APPLICATION_JSON_VALUE)
     public DataCount getDataCount() {
         DataCount dataCount = new DataCount();

--- a/src/main/java/net/gendercomics/api/controller/FileController.java
+++ b/src/main/java/net/gendercomics/api/controller/FileController.java
@@ -1,7 +1,7 @@
 package net.gendercomics.api.controller;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.gendercomics.api.data.service.FileService;
@@ -11,7 +11,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 
-@Api(tags = {"files"})
+@Tag(name = "files")
 @RestController
 @CrossOrigin
 @Slf4j
@@ -21,25 +21,25 @@ public class FileController {
     private final FileService _fileService;
 
     @PostMapping("/files/upload")
-    public void upload(@ApiParam(required = true) @RequestParam("comicId") String comicId,
-                       @ApiParam(required = true) @RequestParam("file") MultipartFile file) {
+    public void upload(@Parameter(required = true) @RequestParam("comicId") String comicId,
+                       @Parameter(required = true) @RequestParam("file") MultipartFile file) {
         _fileService.save(comicId, file);
     }
 
     @DeleteMapping("/files/{comicId}/{fileName}")
-    public void delete(@ApiParam(required = true) @PathVariable("comicId") String comicId,
-                       @ApiParam(required = true) @PathVariable("fileName") String fileName) {
+    public void delete(@Parameter(required = true) @PathVariable("comicId") String comicId,
+                       @Parameter(required = true) @PathVariable("fileName") String fileName) {
         _fileService.delete(comicId, fileName);
     }
 
     @GetMapping("/files/dnb/cover/available/{isbn}")
-    public boolean dnbHasCover(@ApiParam(required = true) @PathVariable("isbn") String isbn) {
+    public boolean dnbHasCover(@Parameter(required = true) @PathVariable("isbn") String isbn) {
         return _fileService.hasDnbCover(isbn);
     }
 
     @PostMapping("/files/dnb/cover/download")
-    public String downloadDnbCover(@ApiParam(required = true) @RequestParam("comicId") String comicId,
-                                   @ApiParam(required = true) @RequestParam("isbn") String isbn) {
+    public String downloadDnbCover(@Parameter(required = true) @RequestParam("comicId") String comicId,
+                                   @Parameter(required = true) @RequestParam("isbn") String isbn) {
         try {
             return _fileService.saveDnbCover(comicId, isbn);
         } catch (IOException e) {

--- a/src/main/java/net/gendercomics/api/controller/KeywordController.java
+++ b/src/main/java/net/gendercomics/api/controller/KeywordController.java
@@ -1,21 +1,20 @@
 package net.gendercomics.api.controller;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import net.gendercomics.api.data.service.KeywordService;
 import net.gendercomics.api.model.Keyword;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
-import springfox.documentation.annotations.ApiIgnore;
 
 import java.security.Principal;
 import java.util.List;
 import java.util.Optional;
 
-@Api(tags = {"keywords"})
+@Tag(name = "keywords")
 @RestController
 @CrossOrigin
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
@@ -23,19 +22,19 @@ public class KeywordController {
 
     private final KeywordService _keywordService;
 
-    @ApiOperation("get all keywords")
+    @Operation(summary = "get all keywords")
     @GetMapping(path = "/keywords", produces = MediaType.APPLICATION_JSON_VALUE)
     public List<Keyword> getKeywords(@RequestParam Optional<String> type) {
         return type.map(_keywordService::findByType).orElseGet(_keywordService::findAll);
     }
 
-    @ApiOperation("get a keyword")
+    @Operation(summary = "get a keyword")
     @GetMapping(path = "/keywords/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public Keyword getKeyword(@ApiParam @PathVariable("id") String id) {
+    public Keyword getKeyword(@Parameter @PathVariable("id") String id) {
         return _keywordService.getKeyword(id);
     }
 
-    @ApiOperation("get top level keywords")
+    @Operation(summary = "get top level keywords")
     @GetMapping(path = "/keywords/top", produces = MediaType.APPLICATION_JSON_VALUE)
     public List<Keyword> getTopLevelKeywords() {
         return _keywordService.findTopLevelKeywords();
@@ -43,21 +42,21 @@ public class KeywordController {
 
     /*** admin endpoints - secured, only authorized access allowed ***/
 
-    @ApiOperation("insert a keyword")
+    @Operation(summary = "insert a keyword")
     @PostMapping(path = "/keywords")
-    public Keyword insertRole(@ApiIgnore Principal principal, @ApiParam(required = true) @RequestBody Keyword keyword) {
+    public Keyword insertRole(@Parameter(hidden = true) Principal principal, @Parameter(required = true) @RequestBody Keyword keyword) {
         return _keywordService.save(keyword, principal.getName());
     }
 
-    @ApiOperation("update a keyword")
+    @Operation(summary = "update a keyword")
     @PutMapping(path = "/keywords/{id}")
-    public Keyword saveRole(@ApiIgnore Principal principal, @ApiParam(required = true) @RequestBody Keyword keyword) {
+    public Keyword saveRole(@Parameter(hidden = true) Principal principal, @Parameter(required = true) @RequestBody Keyword keyword) {
         return _keywordService.save(keyword, principal.getName());
     }
 
-    @ApiOperation("delete a keyword")
+    @Operation(summary = "delete a keyword")
     @DeleteMapping(path = "/keywords/{id}")
-    public void deleteKeyword(@ApiIgnore Principal principal, @ApiParam(required = true) @PathVariable String id) {
+    public void deleteKeyword(@Parameter(hidden = true) Principal principal, @Parameter(required = true) @PathVariable String id) {
         _keywordService.delete(id);
     }
 

--- a/src/main/java/net/gendercomics/api/controller/MigrationController.java
+++ b/src/main/java/net/gendercomics/api/controller/MigrationController.java
@@ -1,7 +1,7 @@
 package net.gendercomics.api.controller;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import net.gendercomics.api.data.service.MigrationService;
 import net.gendercomics.api.model.MigrationResult;
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Api(tags = {"data migration endpoints"})
+@Tag(name = "data migration endpoints")
 @RestController
 @CrossOrigin
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
@@ -20,21 +20,13 @@ public class MigrationController {
 
     private final MigrationService _migrationService;
 
-    /**
-     * @ApiOperation("execute comments migration from DbRef to relation")
-     * @PostMapping(path = "/migration/comic-comments", produces = MediaType.APPLICATION_JSON_VALUE)
-     * public MigrationResult migrateComicComments() {
-     * return _migrationService.comicCommentToRelation();
-     * }
-     */
-
-    @ApiOperation("list comics with empty hyperlinks")
+    @Operation(summary = "list comics with empty hyperlinks")
     @GetMapping(path = "/migration/list-empty-hyperlinks", produces = MediaType.APPLICATION_JSON_VALUE)
     public MigrationResult listEmptyHyperlinks() {
         return _migrationService.listEmptyHyperlink();
     }
 
-    @ApiOperation("remove empty hyperlinks")
+    @Operation(summary = "remove empty hyperlinks")
     @PostMapping(path = "/migration/remove-empty-hyperlinks", produces = MediaType.APPLICATION_JSON_VALUE)
     public MigrationResult removeEmptyHyperlinks() {
         return _migrationService.removeEmptyHyperlink();

--- a/src/main/java/net/gendercomics/api/controller/NameController.java
+++ b/src/main/java/net/gendercomics/api/controller/NameController.java
@@ -1,7 +1,7 @@
 package net.gendercomics.api.controller;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import net.gendercomics.api.data.service.NameService;
 import net.gendercomics.api.model.Name;
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
-@Api(tags = {"names"})
+@Tag(name = "names")
 @RestController
 @CrossOrigin
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
@@ -21,13 +21,13 @@ public class NameController {
 
     private final NameService _nameService;
 
-    @ApiOperation("get all names")
+    @Operation(summary = "get all names")
     @GetMapping(path = "/names", produces = MediaType.APPLICATION_JSON_VALUE)
     public List<Name> getAllPersons() {
         return _nameService.findAll();
     }
 
-    @ApiOperation("get all creators (searchable names")
+    @Operation(summary = "get all creators (searchable names")
     @GetMapping(path = "/creators", produces = MediaType.APPLICATION_JSON_VALUE)
     public List<Name> getAllCreators() {
         return _nameService.findSearchableNames();

--- a/src/main/java/net/gendercomics/api/controller/PersonController.java
+++ b/src/main/java/net/gendercomics/api/controller/PersonController.java
@@ -1,20 +1,19 @@
 package net.gendercomics.api.controller;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import net.gendercomics.api.data.service.PersonService;
 import net.gendercomics.api.model.Person;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
-import springfox.documentation.annotations.ApiIgnore;
 
 import java.security.Principal;
 import java.util.List;
 
-@Api(tags = {"persons"})
+@Tag(name = "persons")
 @RestController
 @CrossOrigin
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
@@ -22,43 +21,35 @@ public class PersonController {
 
     private final PersonService _personService;
 
-    @ApiOperation("get all persons")
+    @Operation(summary = "get all persons")
     @GetMapping(path = "/persons", produces = MediaType.APPLICATION_JSON_VALUE)
     public List<Person> getAllPersons() {
         return _personService.findAll();
     }
 
-    @ApiOperation("get person by id")
+    @Operation(summary = "get person by id")
     @GetMapping(path = "/persons/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public Person getPerson(@ApiParam @PathVariable("id") String id) {
+    public Person getPerson(@Parameter @PathVariable("id") String id) {
         return _personService.getPerson(id);
     }
 
-    /*
-    @ApiOperation("get person by name")
-    @GetMapping(path = "/persons/name/{name}", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
-    public List<Person> getPersonBySearchTerm(@ApiParam @PathVariable("name") String name) {
-        return _personService.findByName(name);
-    }
-     */
-
     /*** admin endpoints - secured, only authorized access allowed ***/
 
-    @ApiOperation("insert a person")
+    @Operation(summary = "insert a person")
     @PostMapping(path = "/persons")
-    public Person insertPerson(@ApiIgnore Principal principal, @ApiParam(required = true) @RequestBody Person person) {
+    public Person insertPerson(@Parameter(hidden = true) Principal principal, @Parameter(required = true) @RequestBody Person person) {
         return _personService.insert(person, principal.getName());
     }
 
-    @ApiOperation("update a person")
+    @Operation(summary = "update a person")
     @PutMapping(path = "/persons/{id}")
-    public Person savePerson(@ApiIgnore Principal principal, @ApiParam(required = true) @RequestBody Person person) {
+    public Person savePerson(@Parameter(hidden = true) Principal principal, @Parameter(required = true) @RequestBody Person person) {
         return _personService.save(person, principal.getName());
     }
 
-    @ApiOperation("delete a person")
+    @Operation(summary = "delete a person")
     @DeleteMapping(path = "/persons/{id}")
-    public void deletePerson(@ApiIgnore Principal principal, @ApiParam(required = true) @PathVariable String id) {
+    public void deletePerson(@Parameter(hidden = true) Principal principal, @Parameter(required = true) @PathVariable String id) {
         _personService.delete(id);
     }
 

--- a/src/main/java/net/gendercomics/api/controller/PredicateController.java
+++ b/src/main/java/net/gendercomics/api/controller/PredicateController.java
@@ -1,8 +1,8 @@
 package net.gendercomics.api.controller;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import net.gendercomics.api.data.NotFoundException;
 import net.gendercomics.api.data.service.PredicateService;
@@ -10,12 +10,11 @@ import net.gendercomics.api.model.Predicate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
-import springfox.documentation.annotations.ApiIgnore;
 
 import java.security.Principal;
 import java.util.List;
 
-@Api(tags = {"predicates"})
+@Tag(name = "predicates")
 @RestController
 @CrossOrigin
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
@@ -23,7 +22,7 @@ public class PredicateController {
 
     private final PredicateService _predicateService;
 
-    @ApiOperation("get all predicates")
+    @Operation(summary = "get all predicates")
     @GetMapping(path = "/predicates", produces = MediaType.APPLICATION_JSON_VALUE)
     public List<Predicate> getAllPredicates() {
         return _predicateService.findAll();
@@ -31,26 +30,26 @@ public class PredicateController {
 
     /*** admin endpoints - secured, only authorized access allowed ***/
 
-    @ApiOperation("insert a predicate")
+    @Operation(summary = "insert a predicate")
     @PostMapping(path = "/predicates")
-    public Predicate insertPredicate(@ApiIgnore Principal principal,
-                                     @ApiParam(required = true) @RequestParam("de") String de,
-                                     @ApiParam(required = true) @RequestParam("en") String en) {
+    public Predicate insertPredicate(@Parameter(hidden = true) Principal principal,
+                                     @Parameter(required = true) @RequestParam("de") String de,
+                                     @Parameter(required = true) @RequestParam("en") String en) {
         return _predicateService.save(de, en, principal.getName());
     }
 
-    @ApiOperation("save a predicate")
+    @Operation(summary = "save a predicate")
     @PutMapping(path = "/predicates/{id}")
-    public Predicate savePredicate(@ApiIgnore Principal principal,
-                                   @ApiParam(required = true) @PathVariable("id") String id,
-                                   @ApiParam(required = true) @RequestParam("de") String de,
-                                   @ApiParam(required = true) @RequestParam("en") String en) throws NotFoundException {
+    public Predicate savePredicate(@Parameter(hidden = true) Principal principal,
+                                   @Parameter(required = true) @PathVariable("id") String id,
+                                   @Parameter(required = true) @RequestParam("de") String de,
+                                   @Parameter(required = true) @RequestParam("en") String en) throws NotFoundException {
         return _predicateService.save(id, de, en, principal.getName());
     }
 
-    @ApiOperation("delete a predicate")
+    @Operation(summary = "delete a predicate")
     @DeleteMapping(path = "/predicates/{id}")
-    public void deletePredicate(@ApiParam(required = true) @PathVariable("id") String id) {
+    public void deletePredicate(@Parameter(required = true) @PathVariable("id") String id) {
         _predicateService.delete(id);
     }
 }

--- a/src/main/java/net/gendercomics/api/controller/PublisherController.java
+++ b/src/main/java/net/gendercomics/api/controller/PublisherController.java
@@ -3,18 +3,17 @@ package net.gendercomics.api.controller;
 import java.security.Principal;
 import java.util.List;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import net.gendercomics.api.data.service.PublisherService;
 import net.gendercomics.api.model.Publisher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
-import springfox.documentation.annotations.ApiIgnore;
 
-@Api(tags = {"publishers"})
+@Tag(name = "publishers")
 @RestController
 @CrossOrigin
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
@@ -22,35 +21,35 @@ public class PublisherController {
 
     private final PublisherService _publisherService;
 
-    @ApiOperation("get all publishers")
+    @Operation(summary = "get all publishers")
     @GetMapping(path = "/publishers", produces = MediaType.APPLICATION_JSON_VALUE)
     public List<Publisher> getAllPublishers() {
         return _publisherService.findAll();
     }
 
-    @ApiOperation("get a publisher")
+    @Operation(summary = "get a publisher")
     @GetMapping(path = "/publishers/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public Publisher getPublisher(@ApiParam @PathVariable("id") String id) {
+    public Publisher getPublisher(@Parameter @PathVariable("id") String id) {
         return _publisherService.getPublisher(id);
     }
 
     /*** admin endpoints - secured, only authorized access allowed ***/
 
-    @ApiOperation("insert a publisher")
+    @Operation(summary = "insert a publisher")
     @PostMapping(path = "/publishers")
-    public Publisher insertPublisher(@ApiIgnore Principal principal, @ApiParam(required = true) @RequestBody Publisher publisher) {
+    public Publisher insertPublisher(@Parameter(hidden = true) Principal principal, @Parameter(required = true) @RequestBody Publisher publisher) {
         return _publisherService.insert(publisher, principal.getName());
     }
 
-    @ApiOperation("update a publisher")
+    @Operation(summary = "update a publisher")
     @PutMapping(path = "/publishers/{id}")
-    public Publisher savePublisher(@ApiIgnore Principal principal, @ApiParam(required = true) @RequestBody Publisher publisher) {
+    public Publisher savePublisher(@Parameter(hidden = true) Principal principal, @Parameter(required = true) @RequestBody Publisher publisher) {
         return _publisherService.save(publisher, principal.getName());
     }
 
-    @ApiOperation("delete a publisher")
+    @Operation(summary = "delete a publisher")
     @DeleteMapping(path = "/publishers/{id}")
-    public void deletePerson(@ApiIgnore Principal principal, @ApiParam(required = true) @PathVariable String id) {
+    public void deletePerson(@Parameter(hidden = true) Principal principal, @Parameter(required = true) @PathVariable String id) {
         _publisherService.delete(id);
     }
 }

--- a/src/main/java/net/gendercomics/api/controller/RoleController.java
+++ b/src/main/java/net/gendercomics/api/controller/RoleController.java
@@ -3,18 +3,17 @@ package net.gendercomics.api.controller;
 import java.security.Principal;
 import java.util.List;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import net.gendercomics.api.data.service.RoleService;
 import net.gendercomics.api.model.Role;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
-import springfox.documentation.annotations.ApiIgnore;
 
-@Api(tags = {"roles"})
+@Tag(name = "roles")
 @RestController
 @CrossOrigin
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
@@ -22,35 +21,35 @@ public class RoleController {
 
     private final RoleService _roleService;
 
-    @ApiOperation("get all roles")
+    @Operation(summary = "get all roles")
     @GetMapping(path = "/roles", produces = MediaType.APPLICATION_JSON_VALUE)
     public List<Role> getAllRoles() {
         return _roleService.findAll();
     }
 
-    @ApiOperation("get a role")
+    @Operation(summary = "get a role")
     @GetMapping(path = "/roles/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public Role getRole(@ApiParam @PathVariable("id") String id) {
+    public Role getRole(@Parameter @PathVariable("id") String id) {
         return _roleService.getRole(id);
     }
 
     /*** admin endpoints - secured, only authorized access allowed ***/
 
-    @ApiOperation("insert a role")
+    @Operation(summary = "insert a role")
     @PostMapping(path = "/roles")
-    public Role insertRole(@ApiIgnore Principal principal, @ApiParam(required = true) @RequestBody Role role) {
+    public Role insertRole(@Parameter(hidden = true) Principal principal, @Parameter(required = true) @RequestBody Role role) {
         return _roleService.insert(role, principal.getName());
     }
 
-    @ApiOperation("update a role")
+    @Operation(summary = "update a role")
     @PutMapping(path = "/roles/{id}")
-    public Role saveRole(@ApiIgnore Principal principal, @ApiParam(required = true) @RequestBody Role role) {
+    public Role saveRole(@Parameter(hidden = true) Principal principal, @Parameter(required = true) @RequestBody Role role) {
         return _roleService.save(role, principal.getName());
     }
 
-    @ApiOperation("delete a role")
+    @Operation(summary = "delete a role")
     @DeleteMapping(path = "/roles/{id}")
-    public void deletePerson(@ApiIgnore Principal principal, @ApiParam(required = true) @PathVariable String id) {
+    public void deletePerson(@Parameter(hidden = true) Principal principal, @Parameter(required = true) @PathVariable String id) {
         _roleService.delete(id);
     }
 

--- a/src/main/java/net/gendercomics/api/controller/SearchController.java
+++ b/src/main/java/net/gendercomics/api/controller/SearchController.java
@@ -1,8 +1,8 @@
 package net.gendercomics.api.controller;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import net.gendercomics.api.data.service.SearchService;
 import net.gendercomics.api.model.Comic;
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Api(tags = {"search"})
+@Tag(name = "search")
 @RestController
 @CrossOrigin
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
@@ -22,20 +22,20 @@ public class SearchController {
 
     private final SearchService _searchService;
 
-    @ApiOperation("search for comics in comics, creator and publishers")
+    @Operation(summary = "search for comics in comics, creator and publishers")
     @PostMapping(path = "/search", produces = MediaType.APPLICATION_JSON_VALUE)
-    public List<Comic> searchAndReturnComics(@ApiParam(required = true) @RequestParam("searchTerm") String searchTerm) {
+    public List<Comic> searchAndReturnComics(@Parameter(required = true) @RequestParam("searchTerm") String searchTerm) {
         return _searchService.searchAndReturnComics(searchTerm);
     }
 
-    @ApiOperation("search for comics in comics, creators, publishers and keywords")
+    @Operation(summary = "search for comics in comics, creators, publishers and keywords")
     @PostMapping(path = "/search-web", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public List<Comic> searchAndReturnComics2(@ApiParam(required = true) @RequestBody SearchInput searchInput) {
+    public List<Comic> searchAndReturnComics2(@Parameter(required = true) @RequestBody SearchInput searchInput) {
         return _searchService.searchAndReturnComics(searchInput);
     }
 
     @PostMapping(path = "/search/download", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<String> downloadSearch(@ApiParam(required = true) @RequestBody SearchInput searchInput) {
+    public ResponseEntity<String> downloadSearch(@Parameter(required = true) @RequestBody SearchInput searchInput) {
         String harvard = _searchService.convertResultToHarvard(_searchService.searchAndReturnComics(searchInput));
         return ResponseEntity
                 .ok()

--- a/src/main/java/net/gendercomics/api/controller/TextController.java
+++ b/src/main/java/net/gendercomics/api/controller/TextController.java
@@ -1,18 +1,17 @@
 package net.gendercomics.api.controller;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiParam;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import net.gendercomics.api.data.service.TextService;
 import net.gendercomics.api.model.Text;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
-import springfox.documentation.annotations.ApiIgnore;
 
 import java.security.Principal;
 
-@Api(tags = {"texts"})
+@Tag(name = "texts")
 @RestController
 @CrossOrigin
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
@@ -22,23 +21,23 @@ public class TextController {
 
     /*** admin endpoints - secured, only authorized access allowed ***/
 
-    @ApiOperation("insert a text")
+    @Operation(summary = "insert a text")
     @PostMapping(path = "/texts")
-    public Text insertText(@ApiIgnore Principal principal, @ApiParam(required = true) @RequestBody String value) {
+    public Text insertText(@Parameter(hidden = true) Principal principal, @Parameter(required = true) @RequestBody String value) {
         Text txt = new Text();
         txt.setValue(value);
         return _textService.save(txt, principal.getName());
     }
 
-    @ApiOperation("update a text")
+    @Operation(summary = "update a text")
     @PutMapping(path = "/texts/{id}")
-    public Text updateText(@ApiIgnore Principal principal, @ApiParam(required = true) @RequestBody Text text) {
+    public Text updateText(@Parameter(hidden = true) Principal principal, @Parameter(required = true) @RequestBody Text text) {
         return _textService.save(text, principal.getName());
     }
 
-    @ApiOperation("delete a text")
+    @Operation(summary = "delete a text")
     @DeleteMapping(path = "/texts/{id}")
-    public void deleteText(@ApiParam(required = true) @PathVariable String id) {
+    public void deleteText(@Parameter(required = true) @PathVariable String id) {
         _textService.delete(id);
     }
 }

--- a/src/main/java/net/gendercomics/api/model/Comic.java
+++ b/src/main/java/net/gendercomics/api/model/Comic.java
@@ -1,8 +1,7 @@
 package net.gendercomics.api.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -25,7 +24,7 @@ import java.util.stream.Collectors;
 @Setter
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Document(collection = "comics")
-@ApiModel(description = "comic book model")
+@Schema(description = "comic book model")
 @CompoundIndexes(value = {
         @CompoundIndex(name = "comic_title_issue_index", def = "{'title':1, 'issue':1}", sparse = true)
 })
@@ -34,73 +33,73 @@ public class Comic implements Comparable<Comic>, DisplayName, DisplayNameI18n {
     @EqualsAndHashCode.Include
     private String id;
 
-    @ApiModelProperty(value = "metadata", required = true)
+    @Schema(description = "metadata", required = true)
     private MetaData metaData;
 
-    @ApiModelProperty(value = "comic book title", required = true)
+    @Schema(description = "comic book title", required = true)
     @EqualsAndHashCode.Include
     @Indexed(name = "comic_title_index")
     @TextIndexed
     private String title;
 
-    @ApiModelProperty(value = "comic book subtitle")
+    @Schema(description = "comic book subtitle")
     @EqualsAndHashCode.Include
     @TextIndexed
     private String subTitle;
 
-    @ApiModelProperty(value = "magazine issue")
+    @Schema(description = "magazine issue")
     private String issue;
 
-    @ApiModelProperty(value = "magazine issue title")
+    @Schema(description = "magazine issue title")
     private String issueTitle;
 
-    @ApiModelProperty(value = "comic book type (comic, magazine, anthology, webcomic, comic-series, publishing-series)", required = true)
+    @Schema(description = "comic book type (comic, magazine, anthology, webcomic, comic-series, publishing-series)", required = true)
     private ComicType type;
 
-    @ApiModelProperty(value = "list of creators")
+    @Schema(description = "list of creators")
     private List<Creator> creators;
 
-    @ApiModelProperty(value = "list of publishers")
+    @Schema(description = "list of publishers")
     @DBRef
     private List<Publisher> publishers;
 
-    @ApiModelProperty(value = "list of location changes for publishers")
+    @Schema(description = "list of location changes for publishers")
     private Map<String, String> publisherOverrides;
 
-    @ApiModelProperty(value = "printer")
+    @Schema(description = "printer")
     private String printer;
 
-    @ApiModelProperty(value = "year of publication")
+    @Schema(description = "year of publication")
     private String year;
 
-    @ApiModelProperty(value = "edition")
+    @Schema(description = "edition")
     private String edition;
 
-    @ApiModelProperty(value = "list of hyperlinks (url, last accessed")
+    @Schema(description = "list of hyperlinks (url, last accessed")
     private List<HyperLink> hyperLinks;
 
-    @ApiModelProperty(value = "isbn")
+    @Schema(description = "isbn")
     private String isbn;
 
-    @ApiModelProperty(value = "list part of publishing or comic series")
+    @Schema(description = "list part of publishing or comic series")
     private List<Series> seriesList;
 
-    @ApiModelProperty(value = "part of publication (comic)")
+    @Schema(description = "part of publication (comic)")
     private PartOf partOf;
 
-    @ApiModelProperty(value = "list of genres (keywords)")
+    @Schema(description = "list of genres (keywords)")
     @DBRef
     private List<Keyword> genres;
 
-    @ApiModelProperty(value = "list of keywords")
+    @Schema(description = "list of keywords")
     @DBRef
     private List<Keyword> keywords;
 
-    @ApiModelProperty(value = "list of comments")
+    @Schema(description = "list of comments")
     @DBRef
     private List<Text> comments;
 
-    @ApiModelProperty(value = "cover image file name")
+    @Schema(description = "cover image file name")
     private String cover;
 
     @Override

--- a/src/main/java/net/gendercomics/api/model/HyperLink.java
+++ b/src/main/java/net/gendercomics/api/model/HyperLink.java
@@ -1,6 +1,6 @@
 package net.gendercomics.api.model;
 
-import io.swagger.annotations.ApiModel;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -8,7 +8,7 @@ import java.util.Date;
 
 @Getter
 @Setter
-@ApiModel(description = "keyword")
+@Schema(description = "keyword")
 public class HyperLink {
 
     String url;

--- a/src/main/java/net/gendercomics/api/model/Keyword.java
+++ b/src/main/java/net/gendercomics/api/model/Keyword.java
@@ -2,8 +2,7 @@ package net.gendercomics.api.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import net.gendercomics.api.model.jackson.KeywordDeserializer;
 import org.springframework.data.annotation.Transient;
@@ -19,7 +18,7 @@ import java.util.stream.Collectors;
 @NoArgsConstructor
 @RequiredArgsConstructor
 @Document(collection = "keywords")
-@ApiModel(description = "keyword")
+@Schema(description = "keyword")
 @JsonDeserialize(using = KeywordDeserializer.class)
 public class Keyword implements DisplayNameI18n, Comparable<Keyword> {
 
@@ -27,25 +26,25 @@ public class Keyword implements DisplayNameI18n, Comparable<Keyword> {
     private String id;
 
     @NonNull
-    @ApiModelProperty(value = "metadata")
+    @Schema(description = "metadata")
     private MetaData metaData;
 
     @NonNull
-    @ApiModelProperty(value = "keyword type (content)", required = true)
+    @Schema(description = "keyword type (content)", required = true)
     private KeywordType type;
 
     @NonNull
-    @ApiModelProperty(value = "list of keywords (one list entry per language)", required = true)
+    @Schema(description = "list of keywords (one list entry per language)", required = true)
     private Map<Language, KeywordValue> values;
 
-    @ApiModelProperty(value = "list of relations")
+    @Schema(description = "list of relations")
     @Transient
     private List<Relation> relations;
 
-    @ApiModelProperty(hidden = true)
+    @Schema(hidden = true)
     private List<RelationIds> relationIds;
 
-    @ApiModelProperty(hidden = true)
+    @Schema(hidden = true)
     @Transient
     private Language currentLanguage = Language.de;
 

--- a/src/main/java/net/gendercomics/api/model/KeywordValue.java
+++ b/src/main/java/net/gendercomics/api/model/KeywordValue.java
@@ -1,7 +1,6 @@
 package net.gendercomics.api.model;
 
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,18 +12,18 @@ import org.springframework.data.mongodb.core.index.CompoundIndexes;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@ApiModel(description = "keyword value per language")
+@Schema(description = "keyword value per language")
 @CompoundIndexes(value = {
         @CompoundIndex(name = "keyword_value_index", def = "{'name':1, 'language':1}", unique = true, sparse = true)
 })
 public class KeywordValue {
 
-    @ApiModelProperty(value = "keyword name", required = true)
+    @Schema(description = "keyword name", required = true)
     private String name;
 
-    @ApiModelProperty(value = "keyword description")
+    @Schema(description = "keyword description")
     private String description;
 
-    @ApiModelProperty(value = "ISO-639-1 two letter language code", required = true)
+    @Schema(description = "ISO-639-1 two letter language code", required = true)
     private Language language;
 }

--- a/src/main/java/net/gendercomics/api/model/MetaData.java
+++ b/src/main/java/net/gendercomics/api/model/MetaData.java
@@ -2,8 +2,7 @@ package net.gendercomics.api.model;
 
 import java.util.Date;
 
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,17 +12,17 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-@ApiModel(description = "Metadata for database entities")
+@Schema(description = "Metadata for database entities")
 public class MetaData {
 
-    @ApiModelProperty(value = "Date on which the entry was created", required = true)
+    @Schema(description = "Date on which the entry was created", required = true)
     private Date createdOn;
-    @ApiModelProperty(value = "User who created the entry", required = true)
+    @Schema(description = "User who created the entry", required = true)
     private String createdBy;
-    @ApiModelProperty(value = "Date on which the entry was modified")
+    @Schema(description = "Date on which the entry was modified")
     private Date changedOn;
-    @ApiModelProperty(value = "User who modified the entry")
+    @Schema(description = "User who modified the entry")
     private String changedBy;
-    @ApiModelProperty(value = "Status of entry: DRAFT|REVIEW|FINAL, default value = DRAFT")
+    @Schema(description = "Status of entry: DRAFT|REVIEW|FINAL, default value = DRAFT")
     private Status status = Status.DRAFT;
 }

--- a/src/main/java/net/gendercomics/api/model/MigrationResult.java
+++ b/src/main/java/net/gendercomics/api/model/MigrationResult.java
@@ -1,12 +1,12 @@
 package net.gendercomics.api.model;
 
-import io.swagger.annotations.ApiModel;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
 import java.util.List;
 
 @Data
-@ApiModel(description = "migration result model")
+@Schema(description = "migration result model")
 public class MigrationResult {
 
     public static final String OK = "OK";

--- a/src/main/java/net/gendercomics/api/model/Name.java
+++ b/src/main/java/net/gendercomics/api/model/Name.java
@@ -1,6 +1,6 @@
 package net.gendercomics.api.model;
 
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.data.mongodb.core.index.CompoundIndex;
@@ -20,20 +20,20 @@ public class Name implements Comparable<Name> {
 
     private String id;
 
-    @ApiModelProperty(value = "first name")
+    @Schema(description = "first name")
     private String firstName;
 
-    @ApiModelProperty(value = "last name")
+    @Schema(description = "last name")
     private String lastName;
 
     @Indexed(name = "name_index", unique = true, sparse = true)
-    @ApiModelProperty(value = "name value")
+    @Schema(description = "name value")
     private String name;
 
-    @ApiModelProperty(value = "true if name is a pseudonym")
+    @Schema(description = "true if name is a pseudonym")
     private boolean pseudonym;
 
-    @ApiModelProperty(value = "true if name entity shall be searchable (e.g. to be referenced as comic creator)")
+    @Schema(description = "true if name entity shall be searchable (e.g. to be referenced as comic creator)")
     private boolean searchable;
 
     @Transient

--- a/src/main/java/net/gendercomics/api/model/PartOf.java
+++ b/src/main/java/net/gendercomics/api/model/PartOf.java
@@ -1,21 +1,20 @@
 package net.gendercomics.api.model;
 
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.data.mongodb.core.mapping.DBRef;
 
 @Getter
 @Setter
-@ApiModel(description = "object containing the information ")
+@Schema(description = "object containing the information ")
 public class PartOf {
 
     @DBRef
-    @ApiModelProperty(value = "references comic", required = true)
+    @Schema(description = "references comic", required = true)
     private Comic comic;
 
-    @ApiModelProperty(value = "pages in the referenced comic")
+    @Schema(description = "pages in the referenced comic")
     private String pages;
 
 }

--- a/src/main/java/net/gendercomics/api/model/Person.java
+++ b/src/main/java/net/gendercomics/api/model/Person.java
@@ -1,7 +1,6 @@
 package net.gendercomics.api.model;
 
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.data.mongodb.core.index.CompoundIndex;
@@ -16,20 +15,20 @@ import java.util.List;
 @Getter
 @Setter
 @Document("persons")
-@ApiModel(description = "persons involved in the process of creating comics")
+@Schema(description = "persons involved in the process of creating comics")
 public class Person implements Comparable<Person> {
 
     private String id;
 
     @DBRef
-    @ApiModelProperty(value = "list of names", required = true)
+    @Schema(description = "list of names", required = true)
     private List<Name> names;
 
     @Indexed(name = "wikidata_index", unique = true, sparse = true)
-    @ApiModelProperty(value = "wikidata")
+    @Schema(description = "wikidata")
     private String wikiData;
 
-    @ApiModelProperty(value = "metadata", required = true)
+    @Schema(description = "metadata", required = true)
     private MetaData metaData;
 
     @Transient

--- a/src/main/java/net/gendercomics/api/model/Predicate.java
+++ b/src/main/java/net/gendercomics/api/model/Predicate.java
@@ -1,6 +1,6 @@
 package net.gendercomics.api.model;
 
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -14,10 +14,10 @@ public class Predicate implements DisplayNameI18n, Comparable<Predicate> {
 
     private String id;
 
-    @ApiModelProperty(value = "list of predicate values (one list entry per language)", required = true)
+    @Schema(description = "list of predicate values (one list entry per language)", required = true)
     private Map<Language, String> values;
 
-    @ApiModelProperty(value = "metadata", required = true)
+    @Schema(description = "metadata", required = true)
     private MetaData metaData;
 
     @Override

--- a/src/main/java/net/gendercomics/api/model/Publisher.java
+++ b/src/main/java/net/gendercomics/api/model/Publisher.java
@@ -1,7 +1,6 @@
 package net.gendercomics.api.model;
 
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.data.annotation.Transient;
@@ -15,21 +14,21 @@ import java.util.Map;
 @Getter
 @Setter
 @Document("publishers")
-@ApiModel(description = "comic book publisher")
+@Schema(description = "comic book publisher")
 public class Publisher implements Comparable<Publisher>, DisplayNameI18n {
 
     private String id;
     @Indexed(name = "publisher_name_index", unique = true, direction = IndexDirection.ASCENDING)
-    @ApiModelProperty(value = "publisher name", required = true)
+    @Schema(description = "publisher name", required = true)
     private String name;
-    @ApiModelProperty(value = "publisher location", required = true)
+    @Schema(description = "publisher location", required = true)
     private String location;
-    @ApiModelProperty(value = "URL to publisher website")
+    @Schema(description = "URL to publisher website")
     private String url;
-    @ApiModelProperty(value = "metadata", required = true)
+    @Schema(description = "metadata", required = true)
     private MetaData metaData;
     @Transient
-    @ApiModelProperty(value = "location override related to specific comic (transient)", required = true)
+    @Schema(description = "location override related to specific comic (transient)", required = true)
     private String locationOverride;
 
     @Override

--- a/src/main/java/net/gendercomics/api/model/Relation.java
+++ b/src/main/java/net/gendercomics/api/model/Relation.java
@@ -1,24 +1,23 @@
 package net.gendercomics.api.model;
 
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@ApiModel(description = "relation model")
+@Schema(description = "relation model")
 public class Relation {
 
-    @ApiModelProperty(value = "the relation source object", required = true)
+    @Schema(description = "the relation source object", required = true)
     private Object source;
 
-    @ApiModelProperty(value = "the relation predicate", required = true)
+    @Schema(description = "the relation predicate", required = true)
     @NonNull
     private Predicate predicate;
 
-    @ApiModelProperty(value = "the relation target object", required = true)
+    @Schema(description = "the relation target object", required = true)
     private Object target;
 
 }

--- a/src/main/java/net/gendercomics/api/model/RelationIds.java
+++ b/src/main/java/net/gendercomics/api/model/RelationIds.java
@@ -1,6 +1,6 @@
 package net.gendercomics.api.model;
 
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -10,13 +10,13 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode()
 public class RelationIds {
 
-    @ApiModelProperty(value = "the relation target object id", required = true)
+    @Schema(description = "the relation target object id", required = true)
     private String sourceId;
 
-    @ApiModelProperty(value = "the relation predicate object id", required = true)
+    @Schema(description = "the relation predicate object id", required = true)
     private String predicateId;
 
-    @ApiModelProperty(value = "the relation target object id", required = true)
+    @Schema(description = "the relation target object id", required = true)
     private String targetId;
 
 }

--- a/src/main/java/net/gendercomics/api/model/Role.java
+++ b/src/main/java/net/gendercomics/api/model/Role.java
@@ -1,7 +1,6 @@
 package net.gendercomics.api.model;
 
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.data.mongodb.core.index.IndexDirection;
@@ -11,16 +10,16 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Getter
 @Setter
 @Document(collection = "roles")
-@ApiModel(description = "roles involved in creating comics")
+@Schema(description = "roles involved in creating comics")
 public class Role {
 
     private String id;
     @Indexed(name = "role_name_index", unique = true, direction = IndexDirection.ASCENDING)
-    @ApiModelProperty(value = "role name (artist, letterer, inker, etc.)", required = true)
+    @Schema(description = "role name (artist, letterer, inker, etc.)", required = true)
     private String name;
-    @ApiModelProperty(value = "detailed description of the role", required = true)
+    @Schema(description = "detailed description of the role", required = true)
     private String description;
-    @ApiModelProperty(value = "metadata", required = true)
+    @Schema(description = "metadata", required = true)
     private MetaData metaData;
 
 }

--- a/src/main/java/net/gendercomics/api/model/SearchFilter.java
+++ b/src/main/java/net/gendercomics/api/model/SearchFilter.java
@@ -1,6 +1,6 @@
 package net.gendercomics.api.model;
 
-import io.swagger.annotations.ApiModel;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,7 +10,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@ApiModel(description = "SearchFilter(comic, creator, publisher, keyword")
+@Schema(description = "SearchFilter(comic, creator, publisher, keyword")
 public class SearchFilter {
     private boolean comics;
     private boolean persons;

--- a/src/main/java/net/gendercomics/api/model/SearchInput.java
+++ b/src/main/java/net/gendercomics/api/model/SearchInput.java
@@ -1,6 +1,6 @@
 package net.gendercomics.api.model;
 
-import io.swagger.annotations.ApiModel;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,7 +10,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@ApiModel(description = "Search input consisting of searchTerm and SearchFilter(comic, creator, publisher, keyword")
+@Schema(description = "Search input consisting of searchTerm and SearchFilter(comic, creator, publisher, keyword")
 public class SearchInput {
     private String searchTerm;
     private SearchFilter searchFilter;

--- a/src/main/java/net/gendercomics/api/model/SearchResult.java
+++ b/src/main/java/net/gendercomics/api/model/SearchResult.java
@@ -1,6 +1,6 @@
 package net.gendercomics.api.model;
 
-import io.swagger.annotations.ApiModel;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,7 +9,7 @@ import lombok.Setter;
 import java.util.Collections;
 import java.util.List;
 
-@ApiModel(description = "object containing the search results")
+@Schema(description = "object containing the search results")
 @Getter
 @Setter
 @AllArgsConstructor

--- a/src/main/java/net/gendercomics/api/model/Series.java
+++ b/src/main/java/net/gendercomics/api/model/Series.java
@@ -1,8 +1,7 @@
 package net.gendercomics.api.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
@@ -11,15 +10,15 @@ import org.springframework.data.mongodb.core.mapping.DBRef;
 
 @Getter
 @Setter
-@ApiModel(description = "object containing the series information")
+@Schema(description = "object containing the series information")
 public class Series {
 
     @DBRef
     @NonNull
-    @ApiModelProperty(value = "references comic", required = true)
+    @Schema(description = "references comic", required = true)
     private Comic comic;
 
-    @ApiModelProperty(value = "volume in series")
+    @Schema(description = "volume in series")
     private String volume;
 
     @Transient

--- a/src/main/java/net/gendercomics/api/model/Text.java
+++ b/src/main/java/net/gendercomics/api/model/Text.java
@@ -1,7 +1,6 @@
 package net.gendercomics.api.model;
 
-import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -11,16 +10,16 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Setter
 @EqualsAndHashCode
 @Document(collection = "texts")
-@ApiModel(description = "text model")
+@Schema(description = "text model")
 public class Text {
 
     private String id;
 
-    @ApiModelProperty(value = "metadata", required = true)
+    @Schema(description = "metadata", required = true)
     @EqualsAndHashCode.Exclude
     private MetaData metaData;
 
-    @ApiModelProperty(value = "contains the (rich)text - formatted by tiptap editor", required = true)
+    @Schema(description = "contains the (rich)text - formatted by tiptap editor", required = true)
     private String value;
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,11 +1,14 @@
 spring:
   profiles:
     active: dev
-  mvc:
-    pathmatch:
-      matching-strategy: ant_path_matcher
   main:
     allow-circular-references: true
+
+springdoc:
+  api-docs:
+    path: /api-docs
+  swagger-ui:
+    path: /swagger-ui.html
 
 server:
   port: 8001


### PR DESCRIPTION
## Summary

Replaces the abandoned SpringFox library (last release Jul 2020) with SpringDoc OpenAPI 1.8.0. SpringFox was also broken with Spring Boot 2.6+ without a path-matching workaround.

**34 files changed:**
- `build.gradle`: remove springfox deps, add `springdoc-openapi-ui:1.8.0`, remove `swaggerVersion`
- `application.yml`: remove `ant_path_matcher` workaround, add SpringDoc paths config
- `GenderComicsApi.java`: replace `@EnableSwagger2` + `Docket` bean with `OpenAPI` bean
- 12 controllers: `@Api` → `@Tag`, `@ApiOperation` → `@Operation`, `@ApiParam` → `@Parameter`, `@ApiIgnore` → `@Parameter(hidden=true)`
- 19 model classes: `@ApiModel` → `@Schema`, `@ApiModelProperty` → `@Schema`, all from `io.swagger.v3.oas.annotations.media.Schema`

SpringDoc 1.x (Spring Boot 2.x) and 2.x (Spring Boot 3.x) share identical annotations — Phase 6 (Boot 3 upgrade) only needs an artifact ID change, no annotation changes.

The `spring.main.allow-circular-references` workaround for the Keycloak adapter is still present and will be removed in Phase 5.

## Test plan

- [x] All 56 tests pass locally
- [x] No `springfox` or `io.swagger.annotations` imports remaining in source

Generated with [Claude Code](https://claude.com/claude-code)