### PR TITLE
deps(phase5): replace Keycloak adapter with Spring Security OAuth2 resource server

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,6 @@ java {
 
 ext {
     junitVersion = '5.11.4'
-    keycloakVersion = '6.0.1'
     lombokVersion = '1.18.38'
     springBootVersion = '2.7.18'
     testContainersVersion = '1.20.6'
@@ -90,8 +89,8 @@ dependencies {
     // SpringDoc OpenAPI
     implementation "org.springdoc:springdoc-openapi-ui:1.8.0"
 
-    // Keycloak
-    implementation "org.keycloak:keycloak-spring-boot-starter:${keycloakVersion}"
+    // Spring Security OAuth2 Resource Server
+    implementation "org.springframework.boot:spring-boot-starter-oauth2-resource-server"
 
     // Test
     testImplementation "org.springframework.boot:spring-boot-starter-test:${springBootVersion}"
@@ -100,11 +99,6 @@ dependencies {
     testImplementation "org.testcontainers:junit-jupiter:${testContainersVersion}"
 }
 
-dependencyManagement {
-    imports {
-        mavenBom "org.keycloak.bom:keycloak-adapter-bom:${keycloakVersion}"
-    }
-}
 
 tasks.withType(JavaCompile) {
     options.compilerArgs << '-Xlint:deprecation'

--- a/src/main/java/net/gendercomics/api/SecurityConfig.java
+++ b/src/main/java/net/gendercomics/api/SecurityConfig.java
@@ -1,94 +1,84 @@
 package net.gendercomics.api;
 
-import org.keycloak.adapters.KeycloakConfigResolver;
-import org.keycloak.adapters.springboot.KeycloakSpringBootConfigResolver;
-import org.keycloak.adapters.springsecurity.authentication.KeycloakAuthenticationProvider;
-import org.keycloak.adapters.springsecurity.config.KeycloakWebSecurityConfigurerAdapter;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.core.authority.mapping.SimpleAuthorityMapper;
-import org.springframework.security.core.session.SessionRegistryImpl;
-import org.springframework.security.web.authentication.session.RegisterSessionAuthenticationStrategy;
-import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Configuration
 @EnableWebSecurity
-public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
-
-    /**
-     * Registers the KeycloakAuthenticationProvider with the authentication manager.
-     */
-    @Autowired
-    public void configureGlobal(AuthenticationManagerBuilder auth) {
-        KeycloakAuthenticationProvider keycloakAuthenticationProvider = keycloakAuthenticationProvider();
-        keycloakAuthenticationProvider.setGrantedAuthoritiesMapper(new SimpleAuthorityMapper());
-        auth.authenticationProvider(keycloakAuthenticationProvider);
-    }
+public class SecurityConfig {
 
     @Bean
-    public KeycloakConfigResolver KeycloakConfigResolver() {
-        return new KeycloakSpringBootConfigResolver();
-    }
-
-    /**
-     * Defines the session authentication strategy.
-     */
-    @Bean
-    @Override
-    protected SessionAuthenticationStrategy sessionAuthenticationStrategy() {
-        return new RegisterSessionAuthenticationStrategy(new SessionRegistryImpl());
-    }
-
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
-        super.configure(http);
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .cors()
-                .and()
-                .csrf()
-                .disable()
-                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-                .sessionAuthenticationStrategy(sessionAuthenticationStrategy())
-                .and()
-                .authorizeRequests()
-                .antMatchers(HttpMethod.POST, "/comics*").hasRole("crud_comics")
-                .antMatchers(HttpMethod.PUT, "/comics*").hasRole("crud_comics")
-                .antMatchers(HttpMethod.DELETE, "/comics*").hasRole("crud_comics")
-                .antMatchers(HttpMethod.POST, "/persons*").hasRole("crud_comics")
-                .antMatchers(HttpMethod.PUT, "/persons*").hasRole("crud_comics")
-                .antMatchers(HttpMethod.DELETE, "/persons*").hasRole("crud_comics")
-                .antMatchers(HttpMethod.POST, "/publishers*").hasRole("crud_comics")
-                .antMatchers(HttpMethod.PUT, "/publishers*").hasRole("crud_comics")
-                .antMatchers(HttpMethod.DELETE, "/publishers*").hasRole("crud_comics")
-                .antMatchers(HttpMethod.POST, "/roles*").hasRole("crud_comics")
-                .antMatchers(HttpMethod.PUT, "/roles*").hasRole("crud_comics")
-                .antMatchers(HttpMethod.DELETE, "/roles*").hasRole("crud_comics")
-                .antMatchers(HttpMethod.POST, "/keywords*").hasRole("crud_comics")
-                .antMatchers(HttpMethod.PUT, "/keywords*").hasRole("crud_comics")
-                .antMatchers(HttpMethod.DELETE, "/keywords*").hasRole("crud_comics")
-                .antMatchers(HttpMethod.POST, "/texts*").hasRole("crud_comics")
-                .antMatchers(HttpMethod.PUT, "/texts*").hasRole("crud_comics")
-                .antMatchers(HttpMethod.DELETE, "/texts*").hasRole("crud_comics")
-                .antMatchers(HttpMethod.POST, "/relations*").hasRole("crud_comics")
-                .antMatchers(HttpMethod.PUT, "/relations*").hasRole("crud_comics")
-                .antMatchers(HttpMethod.DELETE, "/relations*").hasRole("crud_comics")
-                .antMatchers(HttpMethod.POST, "/migration*").hasRole("migration")
-                .antMatchers(HttpMethod.POST, "/files*").hasRole("crud_comics")
-                .antMatchers(HttpMethod.GET, "/images*").hasRole("crud_comics")
-                //.antMatchers(HttpMethod.POST, "/predicates*").hasRole("crud_comics")
-                //.antMatchers(HttpMethod.PUT, "/predicates*").hasRole("crud_comics")
-                .anyRequest().permitAll();
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeRequests(auth -> auth
+                        .antMatchers(HttpMethod.POST,   "/comics*").hasRole("crud_comics")
+                        .antMatchers(HttpMethod.PUT,    "/comics*").hasRole("crud_comics")
+                        .antMatchers(HttpMethod.DELETE, "/comics*").hasRole("crud_comics")
+                        .antMatchers(HttpMethod.POST,   "/persons*").hasRole("crud_comics")
+                        .antMatchers(HttpMethod.PUT,    "/persons*").hasRole("crud_comics")
+                        .antMatchers(HttpMethod.DELETE, "/persons*").hasRole("crud_comics")
+                        .antMatchers(HttpMethod.POST,   "/publishers*").hasRole("crud_comics")
+                        .antMatchers(HttpMethod.PUT,    "/publishers*").hasRole("crud_comics")
+                        .antMatchers(HttpMethod.DELETE, "/publishers*").hasRole("crud_comics")
+                        .antMatchers(HttpMethod.POST,   "/roles*").hasRole("crud_comics")
+                        .antMatchers(HttpMethod.PUT,    "/roles*").hasRole("crud_comics")
+                        .antMatchers(HttpMethod.DELETE, "/roles*").hasRole("crud_comics")
+                        .antMatchers(HttpMethod.POST,   "/keywords*").hasRole("crud_comics")
+                        .antMatchers(HttpMethod.PUT,    "/keywords*").hasRole("crud_comics")
+                        .antMatchers(HttpMethod.DELETE, "/keywords*").hasRole("crud_comics")
+                        .antMatchers(HttpMethod.POST,   "/texts*").hasRole("crud_comics")
+                        .antMatchers(HttpMethod.PUT,    "/texts*").hasRole("crud_comics")
+                        .antMatchers(HttpMethod.DELETE, "/texts*").hasRole("crud_comics")
+                        .antMatchers(HttpMethod.POST,   "/relations*").hasRole("crud_comics")
+                        .antMatchers(HttpMethod.PUT,    "/relations*").hasRole("crud_comics")
+                        .antMatchers(HttpMethod.DELETE, "/relations*").hasRole("crud_comics")
+                        .antMatchers(HttpMethod.POST,   "/migration*").hasRole("migration")
+                        .antMatchers(HttpMethod.POST,   "/files*").hasRole("crud_comics")
+                        .antMatchers(HttpMethod.GET,    "/images*").hasRole("crud_comics")
+                        .anyRequest().permitAll())
+                .oauth2ResourceServer(oauth2 -> oauth2
+                        .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter())));
+        return http.build();
+    }
+
+    @Bean
+    public JwtAuthenticationConverter jwtAuthenticationConverter() {
+        JwtAuthenticationConverter converter = new JwtAuthenticationConverter();
+        // Keycloak stores roles in realm_access.roles; prefix with ROLE_ to match hasRole() checks
+        converter.setJwtGrantedAuthoritiesConverter(jwt -> {
+            Map<String, Object> realmAccess = jwt.getClaimAsMap("realm_access");
+            if (realmAccess == null || !realmAccess.containsKey("roles")) {
+                return Collections.emptyList();
+            }
+            @SuppressWarnings("unchecked")
+            List<String> roles = (List<String>) realmAccess.get("roles");
+            return roles.stream()
+                    .map(role -> new SimpleGrantedAuthority("ROLE_" + role))
+                    .collect(Collectors.toList());
+        });
+        // Preserve existing principal.getName() == preferred_username behaviour
+        converter.setPrincipalClaimName("preferred_username");
+        return converter;
     }
 
     @Bean

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,6 @@
 spring:
   profiles:
     active: dev
-  main:
-    allow-circular-references: true
 
 springdoc:
   api-docs:
@@ -24,15 +22,11 @@ spring:
     multipart:
       max-file-size: 10MB
       max-request-size: 10MB
-
-keycloak:
-  realm: gendercomics
-  resource: gendercomics-admin
-  auth-server-url: http://localhost:81/
-  ssl-required: external
-  public-client: true
-  bearer-only: true
-  principal-attribute: preferred_username
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: http://localhost:81/realms/gendercomics
 
 images:
   path: /Users/michael.litschauer/projects/gendercomics/images/
@@ -53,15 +47,11 @@ spring:
     multipart:
       max-file-size: 2MB
       max-request-size: 10MB
-
-keycloak:
-  realm: gendercomics
-  resource: gendercomics-admin
-  auth-server-url: https://sso.gendercomics.net/
-  ssl-required: external
-  public-client: true
-  bearer-only: true
-  principal-attribute: preferred_username
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: https://sso.gendercomics.net/realms/gendercomics
 
 images:
   path: /images/
@@ -84,15 +74,11 @@ spring:
     multipart:
       max-file-size: 2MB
       max-request-size: 10MB
-
-keycloak:
-  realm: gendercomics
-  resource: gendercomics-admin
-  auth-server-url: https://sso.gendercomics.net/
-  ssl-required: external
-  public-client: true
-  bearer-only: true
-  principal-attribute: preferred_username
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: https://sso.gendercomics.net/realms/gendercomics
 
 images:
   path: /images/

--- a/src/test/java/net/gendercomics/api/GenderComicsApiTests.java
+++ b/src/test/java/net/gendercomics/api/GenderComicsApiTests.java
@@ -1,43 +1,14 @@
 package net.gendercomics.api;
 
-import org.junit.jupiter.api.Disabled;
+import net.gendercomics.api.integrationtest.AbstractIntegrationTest;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.keycloak.adapters.springboot.KeycloakSpringBootProperties;
-import org.springframework.boot.info.BuildProperties;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.mockito.Mockito.mock;
+@TestPropertySource(properties = "spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://localhost:9999/test/jwks.json")
+public class GenderComicsApiTests extends AbstractIntegrationTest {
 
-@Disabled("FIX keycloak properties")
-@ExtendWith(SpringExtension.class)
-//@SpringBootTest
-@TestPropertySource(locations = "classpath:application-test.yml")
-@ContextConfiguration(classes = {GenderComicsApiTests.TestContextConfiguration.class, GenderComicsApi.class})
-public class GenderComicsApiTests {
-
-    @Disabled("FIX keycloak properties")
     @Test
     public void contextLoads() {
-    }
-
-    @TestConfiguration
-    static class TestContextConfiguration {
-
-        @Bean
-        public BuildProperties buildProperties() {
-            return mock(BuildProperties.class);
-        }
-
-        @Bean
-        public KeycloakSpringBootProperties keycloakSpringBootProperties() {
-            return mock(KeycloakSpringBootProperties.class);
-        }
     }
 
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -6,15 +6,11 @@ spring:
     mongodb:
       uri: mongodb://gendercomics_api:test123@localhost:27017/gendercomics-dev?authSource=admin&authMechanism=SCRAM-SHA-1
       auto-index-creation: true
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          jwk-set-uri: http://localhost:9999/test/jwks.json
 
 images:
   path: /Users/mike/projects/gendercomics/images/
-
-keycloak:
-  realm: test
-  resource: test-client
-  auth-server-url: http://localhost:81/
-  ssl-required: none
-  public-client: true
-  bearer-only: true
-  principal-attribute: preferred_username


### PR DESCRIPTION
## Summary

Replaces the deprecated Keycloak Spring Boot adapter 6.0.1 (~2019) with native Spring Security JWT resource server support.

### CVEs closed by removing Keycloak adapter

| CVE | Severity | Component |
|---|---|---|
| CVE-2019-14837 Use of Hard-coded Credentials | 9.1 | keycloak-core |
| CVE-2020-1714 Input Validation | 8.8 | keycloak-core, keycloak-common |
| CVE-2024-29857 Resource Exhaustion | 7.5 | bouncycastle (transitive) |
| CVE-2024-30172 Infinite Loop | 7.5 | bouncycastle (transitive) |
| CVE-2023-6841 JWT handling | 7.5 | keycloak-core |
| + several more medium/low keycloak and bouncycastle CVEs | | |

### Changes

**`SecurityConfig.java`** — full rewrite:
- `KeycloakWebSecurityConfigurerAdapter` → `SecurityFilterChain` bean
- Custom `JwtAuthenticationConverter` reads roles from `realm_access.roles` (Keycloak JWT structure) and prefixes with `ROLE_` to match existing `hasRole("crud_comics")` checks
- `setPrincipalClaimName("preferred_username")` preserves `principal.getName()` behaviour in controllers
- Same authorization rules; CORS config unchanged

**`application.yml`**:
- All `keycloak:` blocks removed; replaced with `spring.security.oauth2.resourceserver.jwt.issuer-uri` per profile
- `spring.main.allow-circular-references: true` removed (was only needed for Keycloak's circular dep)

**`GenderComicsApiTests.java`**:
- `@Disabled` removed — `contextLoads()` now runs
- Extends `AbstractIntegrationTest` (TestContainers MongoDB)
- JWT configured with a static `jwk-set-uri` (not fetched at startup)

## Test plan

- [x] All 56 tests pass, 0 failures
- [x] `GenderComicsApiTests.contextLoads()` re-enabled and passes
- [x] No Keycloak imports remaining in source

Generated with [Claude Code](https://claude.com/claude-code)